### PR TITLE
Fix an invalid col because the start is based 0.

### DIFF
--- a/autoload/ripgrep/line.vim
+++ b/autoload/ripgrep/line.vim
@@ -56,7 +56,8 @@ function! s:process_match(rel, line_object) abort
     let l:linetext = l:match['lines']['text']
     let l:lnum = l:match['line_number']
     let l:submatches = l:match['submatches']
-    let l:start = l:submatches[0]['start']
+    " The start is based 0.
+    let l:start = l:submatches[0]['start'] + 1
     let l:end = l:submatches[0]['end']
     call ripgrep#observe#notify('match', {
         \ 'filename': ripgrep#path#rel(a:rel . l:filename),


### PR DESCRIPTION
```
vim-ripgrep>rg --json fu
{"type":"begin","data":{"path":{"text":"test\\path.vim"}}}
{"type":"match","data":{"path":{"text":"test\\path.vim"},"lines":{"text":"function s:suite.before()\n"},"line_n
umber":6,"absolute_offset":121,"submatches":[{"match":{"text":"fu"},"start":0,"end":2}]}}
{"type":"match","data":{"path":{"text":"test\\path.vim"},"lines":{"text":"endfunction\n"},"line_number":13,"abs
olute_offset":438,"submatches":[{"match":{"text":"fu"},"start":3,"end":5}]}}
{"type":"match","data":{"path":{"text":"test\\path.vim"},"lines":{"text":"function s:suite.after()\n"},"line_nu
...(snip)...
```