### PR TITLE
chore: add 'doc/tags' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Hello! Thanks for the great plugin!

I've added `doc/tags` to `.gitignore`.

This prevents the user's local repository from becoming dirty after they generate help tags with `:helptags`. Since the `doc/tags` file is generated locally, it should not be tracked by Git.